### PR TITLE
default null

### DIFF
--- a/php_yac.h
+++ b/php_yac.h
@@ -39,13 +39,14 @@ extern zend_module_entry yac_module_entry;
 #define YAC_CLASS_PROPERTY_PREFIX  "_prefix"
 #define YAC_ENTRY_COMPRESSED	   0x0020
 #define YAC_ENTRY_TYPE_MASK        0x1f
-#define YAC_ENTRY_ORIG_LEN_SHIT    6 
+#define YAC_ENTRY_ORIG_LEN_SHIT    6
 #define YAC_ENTRY_MAX_ORIG_LEN     ((1U << ((sizeof(int)*8 - YAC_ENTRY_ORIG_LEN_SHIT))) - 1)
 #define YAC_MIN_COMPRESS_THRESHOLD 1024
 
 ZEND_BEGIN_MODULE_GLOBALS(yac)
 	zend_bool enable;
 	zend_bool debug;
+	zend_bool default_null;
 	size_t k_msize;
 	size_t v_msize;
 	ulong compress_threshold;


### PR DESCRIPTION
之前用的某个版本`Yac::get()`返回的默认值为`null`，现在改成了`false`，希望能有个选项可以设置回`null`，以兼容之前版本的代码。
