### PR TITLE
Added a rough GIANT spin lock to avoid racing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $make && make install
    yac.compress_threshold = -1 
 
    yac.enable_cli = 0 ; whether enable yac with cli, default 0
+   
+   yac.use_lock = 0 ; whether enable a giant lock to protect key data structure. Experimental. Default 0
 
 ## Constants
 

--- a/config.m4
+++ b/config.m4
@@ -194,5 +194,5 @@ dnl    ])
 dnl  fi
 
   if test "$PHP_YAC" != "no"; then
-  PHP_NEW_EXTENSION(yac, yac.c storage/yac_storage.c storage/allocator/yac_allocator.c storage/allocator/allocators/shm.c storage/allocator/allocators/mmap.c serializer/php.c serializer/msgpack.c compressor/fastlz/fastlz.c, $ext_shared)
+  PHP_NEW_EXTENSION(yac, yac.c storage/yac_storage.c storage/yac_lock.c storage/allocator/yac_allocator.c storage/allocator/allocators/shm.c storage/allocator/allocators/mmap.c serializer/php.c serializer/msgpack.c compressor/fastlz/fastlz.c, $ext_shared)
 fi

--- a/php_yac.h
+++ b/php_yac.h
@@ -34,7 +34,7 @@ extern zend_module_entry yac_module_entry;
 #include "TSRM.h"
 #endif
 
-#define PHP_YAC_VERSION "0.1.1"
+#define PHP_YAC_VERSION "0.1.1-lock"
 
 #define YAC_CLASS_PROPERTY_PREFIX  "_prefix"
 #define YAC_ENTRY_COMPRESSED	   0x0020
@@ -46,6 +46,7 @@ extern zend_module_entry yac_module_entry;
 ZEND_BEGIN_MODULE_GLOBALS(yac)
 	zend_bool enable;
 	zend_bool debug;
+	zend_bool use_lock;
 	size_t k_msize;
 	size_t v_msize;
 	ulong compress_threshold;

--- a/storage/yac_atomic.h
+++ b/storage/yac_atomic.h
@@ -1,0 +1,11 @@
+#ifndef YAC_ATOMIC_H
+#define YAC_ATOMIC_H
+
+#ifdef __GNUC__
+#define	YAC_CAS(PTR, OLD, NEW)  __sync_bool_compare_and_swap(PTR, OLD, NEW)
+#else
+#error This compiler is NOT supported yet!
+#endif
+
+#endif
+

--- a/storage/yac_lock.c
+++ b/storage/yac_lock.c
@@ -3,6 +3,7 @@
 #include <sys/ipc.h>
 #include <sys/sem.h>
 #include <errno.h>
+#include <sched.h>
 
 #include "yac_atomic.h"
 #include "yac_malloc.h"

--- a/storage/yac_lock.c
+++ b/storage/yac_lock.c
@@ -16,7 +16,7 @@ yac_mutexarray_t *yac_mutexarray_new(int num)
 	int *mem;
 	yac_mutexarray_t *obj;
 
-	if (num<0 || num>YAC_MUTEXARRAY_SIZE_MAX) {
+	if (num<1 || num>YAC_MUTEXARRAY_SIZE_MAX) {
 		return NULL;
 	}
 	obj=USER_ALLOC(sizeof(yac_mutexarray_t)+sizeof(int)*(num-1));
@@ -30,18 +30,22 @@ yac_mutexarray_t *yac_mutexarray_new(int num)
 
 void yac_mutexarray_delete(yac_mutexarray_t *l)
 {
-	USER_FREE(l);
+	if (l!=NULL) {
+		USER_FREE(l);
+	}
 }
 
 int yac_mutexarray_init(yac_mutexarray_t *me)
 {
 	int i;
 
-	if (me->nelms<0 || me->nelms>YAC_MUTEXARRAY_SIZE_MAX) {
-		return -1;
-	}
-	for (i=0;i<me->nelms;++i) {
-		me->elm[i] = MUT_UNLOCKED;
+	if (me!=NULL) {
+		if (me->nelms<0 || me->nelms>YAC_MUTEXARRAY_SIZE_MAX) {
+			return -1;
+		}
+		for (i=0;i<me->nelms;++i) {
+			me->elm[i] = MUT_UNLOCKED;
+		}
 	}
 	return 0;
 }
@@ -52,18 +56,25 @@ void yac_mutexarray_destroy(yac_mutexarray_t *me)
 
 int yac_mutex_lock(yac_mutexarray_t *me, int sub)
 {
-	while (!YAC_CAS(&me->elm[sub], MUT_UNLOCKED, MUT_LOCKED));
+	if (me!=NULL && me->nelms>0) {
+		while (!YAC_CAS(&me->elm[sub], MUT_UNLOCKED, MUT_LOCKED));
+	}
 	return 0;
 }
 
 int yac_mutex_locknb(yac_mutexarray_t *me, int sub)
 {
-	return YAC_CAS(&me->elm[sub], MUT_UNLOCKED, MUT_LOCKED)?0:1;
+	if (me!=NULL && me->nelms>0) {
+		return YAC_CAS(&me->elm[sub], MUT_UNLOCKED, MUT_LOCKED)?0:1;
+	}
+	return 0;
 }
 
 int yac_mutex_unlock(yac_mutexarray_t *me, int sub)
 {
-	me->elm[sub] = MUT_UNLOCKED;
+	if (me!=NULL && me->nelms>0) {
+		me->elm[sub] = MUT_UNLOCKED;
+	}
 	return 0;
 }
 

--- a/storage/yac_lock.c
+++ b/storage/yac_lock.c
@@ -13,7 +13,7 @@
 
 yac_mutexarray_t *yac_mutexarray_new(int num)
 {
-	int *mem;
+	int *mem, i;
 	yac_mutexarray_t *obj;
 
 	if (num<1 || num>YAC_MUTEXARRAY_SIZE_MAX) {
@@ -24,7 +24,9 @@ yac_mutexarray_t *yac_mutexarray_new(int num)
 		return NULL;
 	}
 	obj->nelms = num;
-	memset(obj->elm, MUT_UNLOCKED, sizeof(int)*num);
+	for (i=0;i<obj->nelms;++i) {
+		obj->elm[i] = MUT_UNLOCKED;
+	}
 	return obj;
 }
 

--- a/storage/yac_lock.c
+++ b/storage/yac_lock.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ipc.h>
+#include <sys/sem.h>
+#include <errno.h>
+
+#include "yac_atomic.h"
+#include "yac_malloc.h"
+#include "yac_lock.h"
+
+#define	MUT_UNLOCKED	0
+#define	MUT_LOCKED		1
+
+yac_mutexarray_t *yac_mutexarray_new(int num)
+{
+	int *mem;
+	yac_mutexarray_t *obj;
+
+	if (num<0 || num>YAC_MUTEXARRAY_SIZE_MAX) {
+		return NULL;
+	}
+	obj=USER_ALLOC(sizeof(yac_mutexarray_t)+sizeof(int)*(num-1));
+	if (obj==NULL) {
+		return NULL;
+	}
+	obj->nelms = num;
+	memset(obj->elm, MUT_UNLOCKED, sizeof(int)*num);
+	return obj;
+}
+
+void yac_mutexarray_delete(yac_mutexarray_t *l)
+{
+	USER_FREE(l);
+}
+
+int yac_mutexarray_init(yac_mutexarray_t *me)
+{
+	int i;
+
+	if (me->nelms<0 || me->nelms>YAC_MUTEXARRAY_SIZE_MAX) {
+		return -1;
+	}
+	for (i=0;i<me->nelms;++i) {
+		me->elm[i] = MUT_UNLOCKED;
+	}
+	return 0;
+}
+
+void yac_mutexarray_destroy(yac_mutexarray_t *me)
+{
+}
+
+int yac_mutex_lock(yac_mutexarray_t *me, int sub)
+{
+	while (!YAC_CAS(&me->elm[sub], MUT_UNLOCKED, MUT_LOCKED));
+	return 0;
+}
+
+int yac_mutex_locknb(yac_mutexarray_t *me, int sub)
+{
+	return YAC_CAS(&me->elm[sub], MUT_UNLOCKED, MUT_LOCKED)?0:1;
+}
+
+int yac_mutex_unlock(yac_mutexarray_t *me, int sub)
+{
+	me->elm[sub] = MUT_UNLOCKED;
+	return 0;
+}
+

--- a/storage/yac_lock.h
+++ b/storage/yac_lock.h
@@ -1,0 +1,21 @@
+#ifndef YAC_LOCK_H
+#define YAC_LOCK_H
+
+typedef struct yac_mutexarray_st {
+    int nelms;
+    int elm[1];
+} yac_mutexarray_t;
+
+#define	YAC_MUTEXARRAY_SIZE_MAX	(1024*1024)
+
+yac_mutexarray_t *yac_mutexarray_new(int num);
+void yac_mutexarray_delete(yac_mutexarray_t*);
+
+int yac_mutexarray_init(yac_mutexarray_t*);
+void yac_mutexarray_destroy(yac_mutexarray_t*);
+
+int yac_mutex_lock(yac_mutexarray_t*, int sub);
+int yac_mutex_locknb(yac_mutexarray_t*, int sub);
+int yac_mutex_unlock(yac_mutexarray_t*, int sub);
+
+#endif

--- a/storage/yac_malloc.h
+++ b/storage/yac_malloc.h
@@ -1,0 +1,10 @@
+#ifndef YAC_MALLOC_H
+#define YAC_MALLOC_H
+
+#include "php.h"
+
+#define USER_ALLOC                  emalloc
+#define USER_FREE                   efree
+
+#endif
+

--- a/storage/yac_storage.c
+++ b/storage/yac_storage.c
@@ -315,9 +315,9 @@ int yac_storage_find(char *key, unsigned int len, char **data, unsigned int *siz
 
 	hash = h = yac_inline_hash_func1(key, len);
 	p = &(YAC_SG(slots)[h & YAC_SG(slots_mask)]);
-	LOCK;		// P
+	LOCK;
 	k = *p;
-	UNLOCK;		// V
+	UNLOCK;
 	if (k.val) {
 		char *s;
 		uint i;
@@ -360,9 +360,9 @@ do_verify:
 		for (i = 0; i < 3; i++) {
 			h += seed & YAC_SG(slots_mask);
 			p = &(YAC_SG(slots)[h & YAC_SG(slots_mask)]);
-			LOCK;	// P
+			LOCK;
 			k = *p;
-			UNLOCK;	// V
+			UNLOCK;
 			if (k.h == hash && YAC_KEY_KLEN(k) == len) {
 				v = *(k.val);
 				if (!memcmp(k.key, key, len)) {
@@ -433,9 +433,9 @@ int yac_storage_update(char *key, unsigned int len, char *data, unsigned int siz
 
 	hash = h = yac_inline_hash_func1(key, len);
 	paths[idx++] = p = &(YAC_SG(slots)[h & YAC_SG(slots_mask)]);
-	LOCK;	// P
+	LOCK;
 	k = *p;
-	UNLOCK;	// V
+	UNLOCK;
 	if (k.val) {
 		/* Found the exact match */
 		if (k.h == hash && YAC_KEY_KLEN(k) == len && !memcmp((char *)k.key, key, len)) {
@@ -462,9 +462,9 @@ do_update:
 				k.flag = flag;
 				memcpy(k.key, key, len);
 				YAC_KEY_SET_LEN(k, len, size);
-				LOCK;	// P
+				LOCK;
 				*p = k;
-				UNLOCK;	// V
+				UNLOCK;
 				USER_FREE(s);
 				goto return_1;
 			} else {
@@ -493,9 +493,9 @@ do_update:
 					k.size = real_size;
 					memcpy(k.key, key, len);
 					YAC_KEY_SET_LEN(k, len, size);
-					LOCK;	// P
+					LOCK;
 					*p = k;
-					UNLOCK;	// V
+					UNLOCK;
 					USER_FREE(s);
 					goto return_1;
 				}
@@ -511,9 +511,9 @@ do_update:
 			for (i = 0; i < 3; i++) {
 				h += seed & YAC_SG(slots_mask);
 				paths[idx++] = p = &(YAC_SG(slots)[h & YAC_SG(slots_mask)]);
-				LOCK;	// P
+				LOCK;
 				k = *p;
-				UNLOCK;	// V
+				UNLOCK;
 				if (k.val == NULL) {
 					goto do_add;
 				} else if (k.h == hash && YAC_KEY_KLEN(k) == len && !memcmp((char *)k.key, key, len)) {
@@ -534,9 +534,9 @@ do_update:
 				}
 			}
 			++YAC_SG(kicks);
-			LOCK;	// P
+			LOCK;
 			k = *p;
-			UNLOCK;	// V
+			UNLOCK;
 			k.h = hash;
 
 			goto do_update;
@@ -570,9 +570,9 @@ do_add:
 			} else {
 				k.ttl = 0;
 			}
-			LOCK;	// P
+			LOCK;
 			*p = k;
-			UNLOCK;	// V
+			UNLOCK;
 			USER_FREE(s);
 			goto return_1;
 		}

--- a/storage/yac_storage.c
+++ b/storage/yac_storage.c
@@ -365,7 +365,7 @@ do_verify:
 			UNLOCK;	// V
 			if (k.h == hash && YAC_KEY_KLEN(k) == len) {
 				v = *(k.val);
-				if (!memcmp(p->key, key, len)) {
+				if (!memcmp(k.key, key, len)) {
 					s = USER_ALLOC(YAC_KEY_VLEN(k) + 1);
 					memcpy(s, (char *)k.val->data, YAC_KEY_VLEN(k));
 					goto do_verify;

--- a/storage/yac_storage.c
+++ b/storage/yac_storage.c
@@ -34,6 +34,11 @@ static inline unsigned int yac_storage_align_size(unsigned int size) /* {{{ */ {
 /* }}} */
 
 int yac_storage_startup(unsigned long fsize, unsigned long size, char **msg) /* {{{ */ {
+	return yac_storage_startup_flags(fsize, size, msg, 0);
+}
+/* }}} */
+
+int yac_storage_startup_flags(unsigned long fsize, unsigned long size, char **msg, unsigned long flags) /* {{{ */ {
 	unsigned long real_size;
 		
 	if (!yac_allocator_startup(fsize, size, msg)) {
@@ -56,7 +61,11 @@ int yac_storage_startup(unsigned long fsize, unsigned long size, char **msg) /* 
 
    	memset((char *)YAC_SG(slots), 0, sizeof(yac_kv_key) * real_size);
 
-	YAC_SG(slots_mono_mutex).nelms = 1;
+	if (flags&YAC_FLAGS_USE_LOCK) {
+		YAC_SG(slots_mono_mutex).nelms = 1;
+	} else {
+		YAC_SG(slots_mono_mutex).nelms = 0;
+	}
 	yac_mutexarray_init(&YAC_SG(slots_mono_mutex));
 
 	return 1;

--- a/storage/yac_storage.c
+++ b/storage/yac_storage.c
@@ -360,12 +360,12 @@ do_verify:
 		for (i = 0; i < 3; i++) {
 			h += seed & YAC_SG(slots_mask);
 			p = &(YAC_SG(slots)[h & YAC_SG(slots_mask)]);
-			if (p->h == hash && YAC_KEY_KLEN(*p) == len) {
-				v = *(p->val);
+			LOCK;	// P
+			k = *p;
+			UNLOCK;	// V
+			if (k.h == hash && YAC_KEY_KLEN(k) == len) {
+				v = *(k.val);
 				if (!memcmp(p->key, key, len)) {
-					LOCK;	// P
-					k = *p;
-					UNLOCK;	// V
 					s = USER_ALLOC(YAC_KEY_VLEN(k) + 1);
 					memcpy(s, (char *)k.val->data, YAC_KEY_VLEN(k));
 					goto do_verify;

--- a/storage/yac_storage.c
+++ b/storage/yac_storage.c
@@ -420,6 +420,7 @@ void yac_storage_delete(char *key, unsigned int len, int ttl, unsigned long tv) 
 		}
 	}
 end:
+	return;
 }
 /* }}} */
 

--- a/storage/yac_storage.c
+++ b/storage/yac_storage.c
@@ -306,7 +306,7 @@ static inline unsigned int yac_crc32(char *data, unsigned int size) /* {{{ */ {
 /* }}} */
 
 #define	LOCK	yac_mutex_lock(&YAC_SG(slots_mono_mutex), 0)
-#define	UNLOCK	yac_mutex_lock(&YAC_SG(slots_mono_mutex), 0)
+#define	UNLOCK	yac_mutex_unlock(&YAC_SG(slots_mono_mutex), 0)
 
 int yac_storage_find(char *key, unsigned int len, char **data, unsigned int *size, unsigned int *flag, int *cas, unsigned long tv) /* {{{ */ {
 	ulong h, hash, seed;

--- a/storage/yac_storage.c
+++ b/storage/yac_storage.c
@@ -311,7 +311,7 @@ int yac_storage_find(char *key, unsigned int len, char **data, unsigned int *siz
 	yac_kv_val v;
 
 	hash = h = yac_inline_hash_func1(key, len);
-	yac_mutex_lock(&YAC_SG(slots_mono_mutex), 0);
+	//yac_mutex_lock(&YAC_SG(slots_mono_mutex), 0);
 	p = &(YAC_SG(slots)[h & YAC_SG(slots_mask)]);
 	k = *p;
 	if (k.val) {
@@ -370,10 +370,10 @@ do_verify:
 
 	++YAC_SG(miss);
 return_0:
-	yac_mutex_unlock(&YAC_SG(slots_mono_mutex), 0);
+	//yac_mutex_unlock(&YAC_SG(slots_mono_mutex), 0);
 	return 0;
 return_1:
-	yac_mutex_unlock(&YAC_SG(slots_mono_mutex), 0);
+	//yac_mutex_unlock(&YAC_SG(slots_mono_mutex), 0);
 	return 1;
 }
 /* }}} */

--- a/storage/yac_storage.h
+++ b/storage/yac_storage.h
@@ -107,7 +107,10 @@ extern yac_storage_globals *yac_storage;
 
 #define YAC_SG(element) (yac_storage->element)
 
+#define	YAC_FLAGS_USE_LOCK	0x00000001UL
+
 int yac_storage_startup(unsigned long first_size, unsigned long size, char **err);
+int yac_storage_startup_flags(unsigned long first_size, unsigned long size, char **err, unsigned long flags);
 void yac_storage_shutdown(void);
 int yac_storage_find(char *key, unsigned int len, char **data, unsigned int *size, unsigned int *flag, int *cas, unsigned long tv);
 int yac_storage_update(char *key, unsigned int len, char *data, unsigned int size, unsigned int falg, int ttl, int add, unsigned long tv);

--- a/storage/yac_storage.h
+++ b/storage/yac_storage.h
@@ -18,6 +18,8 @@
 
 /* $Id$ */
 
+#include "yac_lock.h"
+
 #ifndef YAC_STORAGE_H
 #define YAC_STORAGE_H
 
@@ -86,6 +88,7 @@ typedef struct {
 
 typedef struct {
 	yac_kv_key  *slots;
+	yac_mutexarray_t	slots_mono_mutex;
 	unsigned int slots_mask;
 	unsigned int slots_num;
 	unsigned int slots_size;

--- a/yac.c
+++ b/yac.c
@@ -169,7 +169,9 @@ static int yac_add_impl(char *prefix, uint prefix_len, char *key, uint len, zval
 			}
 			break;
 		case IS_ARRAY:
+#ifdef IS_CONSTANT_ARRAY
 		case IS_CONSTANT_ARRAY:
+#endif
 		case IS_OBJECT:
 			{
 				smart_str buf = {0};
@@ -337,7 +339,9 @@ static zval * yac_get_impl(char * prefix, uint prefix_len, char *key, uint len, 
 				}
 				break;
 			case IS_ARRAY:
+#ifdef IS_CONSTANT_ARRAY
 			case IS_CONSTANT_ARRAY:
+#endif
 			case IS_OBJECT:
 				{
 					if ((flag & YAC_ENTRY_COMPRESSED)) {

--- a/yac.c
+++ b/yac.c
@@ -483,13 +483,12 @@ static void yac_delete_multi_impl(char *prefix, uint prefix_len, zval *keys, int
 PHP_METHOD(yac, __construct) {
 	char *prefix;
 	uint len = 0;
-	int use_lock = 0;
 
 	if (!YAC_G(enable)) {
 		return;
 	}
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &prefix, &len, &use_lock) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &prefix, &len) == FAILURE) {
 		return;
 	}
 


### PR DESCRIPTION
Added an experimental giant spin lock
To enable it: set ini entry: yac.use_lock = 1

As a cost of the performance collapsed, you will never get wrong data which you set before.
Note:Data still maybe lost.

Maybe useful for certain occasion.
