### PR TITLE
Replace obsolete AC_TRY_FOO with AC_FOO_IFELSE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -12,7 +12,8 @@ dnl    [  --enable-msgpack       Use Messagepack as serializer])
 
 dnl copied from Zend Optimizer Plus
 AC_MSG_CHECKING(for sysvipc shared memory support)
-AC_TRY_RUN([
+AC_RUN_IFELSE([
+  AC_LANG_SOURCE([[
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/ipc.h>
@@ -76,13 +77,14 @@ int main() {
   }
   return 0;
 }
-],dnl
-AC_DEFINE(HAVE_SHM_IPC, 1, [Define if you have SysV IPC SHM support])
-    msg=yes,msg=no,msg=no)
+]])],[
+  AC_DEFINE(HAVE_SHM_IPC, 1, [Define if you have SysV IPC SHM support])
+  msg=yes],[msg=no],[msg=no])
 AC_MSG_RESULT([$msg])
 
 AC_MSG_CHECKING(for mmap() using MAP_ANON shared memory support)
-AC_TRY_RUN([
+AC_RUN_IFELSE([
+  AC_LANG_SOURCE([[
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/mman.h>
@@ -128,13 +130,14 @@ int main() {
   }
   return 0;
 }
-],dnl
-AC_DEFINE(HAVE_SHM_MMAP_ANON, 1, [Define if you have mmap(MAP_ANON) SHM support])
-    msg=yes,msg=no,msg=no)
+]])],[
+  AC_DEFINE(HAVE_SHM_MMAP_ANON, 1, Define if you have mmap(MAP_ANON) SHM support)
+  msg=yes],[msg=no],[msg=no])
 AC_MSG_RESULT([$msg])
 
 AC_MSG_CHECKING(for mmap() using /dev/zero shared memory support)
-AC_TRY_RUN([
+AC_RUN_IFELSE([
+  AC_LANG_SOURCE([[
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/mman.h>
@@ -183,9 +186,9 @@ int main() {
   }
   return 0;
 }
-],dnl
-AC_DEFINE(HAVE_SHM_MMAP_ZERO, 1, [Define if you have mmap("/dev/zero") SHM support])
-    msg=yes,msg=no,msg=no)
+]])],[
+  AC_DEFINE(HAVE_SHM_MMAP_ZERO, 1, [Define if you have mmap("/dev/zero") SHM support])
+  msg=yes],[msg=no],[msg=no])
 AC_MSG_RESULT([$msg])
 
 dnl  if test "$PHP_MSGPACK" != "no"; then


### PR DESCRIPTION
Hello,

Autoconf made several macros obsolete including the AC_TRY_RUN in 2000 and since Autoconf 2.50:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2

These macros should be replaced with the current AC_FOO_IFELSE instead.

It is fairly safe to upgrade and take the recommendation advice of autoconf upgrade manual since the upgrade should be compatible at least with PHP versions 5.4 and up, on some systems even with PHP 5.3. PHP versions from 5.4 to 7.1 require Autoconf 2.59+ and PHP 7.2+ require Autoconf 2.64+.

This patch was created with the help of autoupdate script:
```bash
autoupdate config.m4
```

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.59/autoconf.pdf
