### PR TITLE
Replace ulong with zend_ulong

### DIFF
--- a/php_yac.h
+++ b/php_yac.h
@@ -48,7 +48,7 @@ ZEND_BEGIN_MODULE_GLOBALS(yac)
 	zend_bool debug;
 	size_t k_msize;
 	size_t v_msize;
-	ulong compress_threshold;
+	zend_ulong compress_threshold;
 	zend_bool enable_cli;
 #ifdef PHP_WIN32
 	char *mmap_base;

--- a/yac.c
+++ b/yac.c
@@ -483,7 +483,7 @@ void yac_delete_impl(char *prefix, uint32_t prefix_len, char *key, uint32_t len,
 	}
 
 	if (ttl) {
-		tv = (ulong)time(NULL);
+		tv = (zend_ulong)time(NULL);
 	}
 
 	yac_storage_delete(key, len, ttl, tv);


### PR DESCRIPTION
As of PHP 7.4.0, portable support of `ulong` has been removed, which
causes builds on Windows (and maybe other systems) to fail.