### PR TITLE
take proto from php_msgpack.h

### DIFF
--- a/serializer/msgpack.c
+++ b/serializer/msgpack.c
@@ -26,12 +26,10 @@
 #ifdef YAC_ENABLE_MSGPACK
 
 #include "php.h"
+#include "ext/msgpack/php_msgpack.h"
 #include "zend_smart_str.h" /* for smart_str */
 
 #include "yac_serializer.h"
-
-extern void php_msgpack_serialize(smart_str *buf, zval *val);
-extern void php_msgpack_unserialize(zval *return_value, char *str, size_t str_len);
 
 int yac_serializer_msgpack_pack(zval *pzval, smart_str *buf, char **msg) /* {{{ */ {
 	php_msgpack_serialize(buf, pzval);


### PR DESCRIPTION
I don't really see any reason to not use the extension provided headers.

I konw redis does some checks, but as far as I know this is not needed, as default include path have all installed headers.
pecl_http also have some check, but this is to allow building with various sources tree.
