### PR TITLE
expose build options in pecl archive

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -211,7 +211,7 @@ if test "$PHP_IGBINARY" != "no"; then
 fi
 
 if test "$PHP_JSON" != "no"; then
-  AC_DEFINE(YAC_ENABLE_JSON, 1, [enable msgpack packager])
+  AC_DEFINE(YAC_ENABLE_JSON, 1, [enable json packager])
   ifdef([PHP_ADD_EXTENSION_DEP],
   [
   PHP_ADD_EXTENSION_DEP(yac, json, true)

--- a/package.xml
+++ b/package.xml
@@ -100,7 +100,11 @@
   </required> 
  </dependencies> 
  <providesextension>yac</providesextension>
- <extsrcrelease />
+ <extsrcrelease>
+  <configureoption name="enable-igbinary" prompt="enable igbinary serializer support?" default="no"/>
+  <configureoption name="enable-json" prompt="enable json serializer support?" default="yes"/>
+  <configureoption name="enable-msgpack" prompt="enable msgpack serializer support?" default="no"/>
+ </extsrcrelease>
  <changelog> 
   <release> 
    <date>2020-03-27</date> 


### PR DESCRIPTION
Probably make sense to make this options available for pecl users.
```
# pecl upgrade -f /work/GIT/pecl-and-ext/yac/yac-2.2.0.tgz 
19 source files, building
running: phpize
Configuring for:
PHP Api Version:         20180731
Zend Module Api No:      20180731
Zend Extension Api No:   320180731
enable igbinary serializer support? [no] : 
enable json serializer support? [yes] : 
enable msgpack serializer support? [no] : 
building in /var/tmp/pear-build-rootFXIYTp/yac-2.2.0
...
checking whether to enable yac support... yes, shared
checking whether to use system FastLZ library... no
checking whether to use igbinary as serializer... yes
checking whether to use msgpack as serializer... no
checking whether to use igbinary as serializer... no
checking for sysvipc shared memory support... yes
...
```

Notice: I set "json" to yes by default, as probably most installation will have it.