### PR TITLE
Fix compatibility with PHP 8

### DIFF
--- a/tests/021.phpt
+++ b/tests/021.phpt
@@ -13,8 +13,12 @@ $yac = new Yac("prefix");
 
 $yac->value = "value";
 
-/* can not used in writen context */
-$yac->foo->bar = "bar";
+try {
+	/* can not used in writen context */
+	$yac->foo->bar = "bar";
+} catch (Error $e) {
+	/* expected exception on PHP 8 */
+}
 
 var_dump($yac->get("value"));
 var_dump($yac->value);

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -17,5 +17,5 @@ var_dump($yac);
 --EXPECTF--
 string(18) "Yac is not enabled"
 
-Notice: Undefined variable: yac in %s022.php on line %d
+%s: Undefined variable%syac in %s022.php on line %d
 NULL

--- a/yac.c
+++ b/yac.c
@@ -504,17 +504,27 @@ static void yac_object_free(zend_object *object) /* {{{ */ {
 }
 /* }}} */
 
-static zval* yac_read_property_ptr(zval *zobj, zval *name, int type, void **cache_slot) /* {{{ */ {
+#if PHP_VERSION_ID < 80000
+static zval* yac_read_property_ptr(zval *zobj, zval *zname, int type, void **cache_slot) /* {{{ */ {
+#else
+static zval* yac_read_property_ptr(zend_object *obj, zend_string *name, int type, void **cache_slot) /* {{{ */ {
+#endif
 	return &EG(error_zval);
 }
 /* }}} */
 
-static zval* yac_read_property(zval *zobj, zval *name, int type, void **cache_slot, zval *rv) /* {{{ */ {
+#if PHP_VERSION_ID < 80000
+static zval* yac_read_property(zval *zobj, zval *zname, int type, void **cache_slot, zval *rv) /* {{{ */ {
+	zend_object *obj = Z_OBJ_P(zobj);
+	zend_string *name = Z_STR_P(zname);
+#else
+static zval* yac_read_property(zend_object *obj, zend_string *name, int type, void **cache_slot, zval *rv) /* {{{ */ {
+#endif
 	if (UNEXPECTED(type == BP_VAR_RW||type == BP_VAR_W)) {
 		return &EG(error_zval);
 	}
 
-	if (yac_get_impl(Z_YACOBJ_P(zobj), Z_STR_P(name), NULL, rv)) {
+	if (yac_get_impl(php_yac_fetch_object(obj), name, NULL, rv)) {
 		return rv;
 	}
 
@@ -522,16 +532,26 @@ static zval* yac_read_property(zval *zobj, zval *name, int type, void **cache_sl
 }
 /* }}} */
 
-static YAC_WHANDLER yac_write_property(zval *zobj, zval *name, zval *value, void **cache_slot) /* {{{ */ {
-	yac_add_impl(Z_YACOBJ_P(zobj), Z_STR_P(name), value, 0, 0);
+#if PHP_VERSION_ID < 80000
+static YAC_WHANDLER yac_write_property(zval *zobj, zval *zname, zval *value, void **cache_slot) /* {{{ */ {
+	yac_add_impl(Z_YACOBJ_P(zobj), Z_STR_P(zname), value, 0, 0);
+#else
+static YAC_WHANDLER yac_write_property(zend_object *obj, zend_string *name, zval *value, void **cache_slot) /* {{{ */ {
+	yac_add_impl(php_yac_fetch_object(obj), name, value, 0, 0);
+#endif
     Z_TRY_ADDREF_P(value);
 
 	YAC_WHANDLER_RET(value);
 }
 /* }}} */
 
-static void yac_unset_property(zval *zobj, zval *name, void **cache_slot) /* {{{ */ {
-	yac_delete_impl(Z_YACOBJ_P(zobj), Z_STR_P(name), 0);
+#if PHP_VERSION_ID < 80000
+static void yac_unset_property(zval *zobj, zval *zname, void **cache_slot) /* {{{ */ {
+	yac_delete_impl(Z_YACOBJ_P(zobj), Z_STR_P(zname), 0);
+#else
+static void yac_unset_property(zend_object *obj, zend_string *name, void **cache_slot) /* {{{ */ {
+	yac_delete_impl(php_yac_fetch_object(obj), name, 0);
+#endif
 }
 /* }}} */
 


### PR DESCRIPTION
Using **8.0.0beta4**, igbinary-3.1.5 and msgpack-master

```
=====================================================================
PASS Check for yac presence [tests/001.phpt] 
PASS Check for yac basic functions [tests/002.phpt] 
PASS Check for yac errors [tests/003.phpt] 
PASS Check for yac ttl [tests/004.phpt] 
PASS Check for yac non-string key [tests/005.phpt] 
PASS Check for yac multi set/get [tests/006.phpt] 
PASS Check for yac info [tests/007.phpt] 
PASS Check for yac prefix [tests/008.phpt] 
PASS Check for yac multi ops [tests/009.phpt] 
PASS Check for yac::flush [tests/010.phpt] 
PASS Check for yac::add [tests/011.phpt] 
SKIP Check for functional apis [tests/012.phpt] reason: Functional style APIs are not enabled
PASS Check for ttl bug [tests/013.phpt] 
PASS Check for ttl bug [tests/014.phpt] 
PASS Check for Yac::dump [tests/015.phpt] 
PASS Check for Yac setter/getter [tests/016.phpt] 
PASS Check for mutiple process [tests/017.phpt] 
PASS Check for yac with json serializer [tests/018.phpt] 
PASS Check for yac with msgpack serializer [tests/019.phpt] 
PASS Check for yac with igbinary serializer [tests/020.phpt] 
PASS Check for yac read/write/unset property [tests/021.phpt] 
PASS Check for yac::__construct with yac.enable=0 [tests/022.phpt] 
PASS Check for inherit from Yac [tests/023.phpt] 
PASS ISSUE #12 segfault if use mmap&k_size bigger than 4M [tests/issue012.phpt] 
=====================================================================

```