### PR TITLE
docs: fix simple typo, hight -> high

### DIFF
--- a/storage/yac_storage.c
+++ b/storage/yac_storage.c
@@ -208,7 +208,7 @@ static inline uint64_t yac_inline_hash_func2(const char *key, uint32_t len) {
  *  order from highest-order term to lowest-order term.  UARTs transmit
  *  characters in order from LSB to MSB.  By storing the CRC this way
  *  we hand it to the UART in the order low-byte to high-byte; the UART
- *  sends each low-bit to hight-bit; and the result is transmission bit
+ *  sends each low-bit to high-bit; and the result is transmission bit
  *  by bit from highest- to lowest-order term without requiring any bit
  *  shuffling on our part.  Reception works similarly
  *


### PR DESCRIPTION
There is a small typo in storage/yac_storage.c.

Should read `high` rather than `hight`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md