### PR TITLE
relax test for 8.1.0beta2

### DIFF
--- a/tests/023.phpt
+++ b/tests/023.phpt
@@ -9,4 +9,4 @@ yac.enable=0
 class Sub extends Yac {};
 ?>
 --EXPECTF--
-Fatal error: Class Sub may not inherit from final class (Yac) in %s023.php on line %d
+Fatal error: Class Sub %s final class %s


### PR DESCRIPTION
Using **8.1.0beta2**
```
========DIFF========
001+ Fatal error: Class Sub cannot extend final class Yac in /dev/shm/BUILD/php81-php-pecl-yac-2.3.0/NTS/tests/023.php on line 2
001- Fatal error: Class Sub may not inherit from final class (Yac) in %s023.php on line %d
========DONE========

```